### PR TITLE
Add tiff to list of valid image types

### DIFF
--- a/lib/lizard/image.rb
+++ b/lib/lizard/image.rb
@@ -6,7 +6,7 @@ require "lizard/histogram"
 module Lizard
   class Image
 
-    TYPES = ['jpeg', 'png', 'gif']
+    TYPES = ['jpeg', 'png', 'gif', 'tiff']
 
     def self.is_image?(data)
       image = Image.new(data)


### PR DESCRIPTION
A tiff filetype is a common filetype in technical applications. So I added this type to lizard. This will add a little value to auch a useful gem. 